### PR TITLE
PEP8 constainst, and format with yaps

### DIFF
--- a/src/mdlg/model/model.py
+++ b/src/mdlg/model/model.py
@@ -1,19 +1,18 @@
-
-
 ZONE_FULL = (0, 0, None, None)
 SIZE_FULL = (None, None)
 ZONE_KEYS = ('x', 'y', 'width', 'height')
 SIZE_KEYS = ('width', 'height')
 
+
 class GalacticaURL:
     # https://gallica.bnf.fr/iiif/ark:/12148/btv1b8470209d/f11/398,195,2317,3945/full/0/native.jpg-1
     def __init__(self, parts):
         self.params = parts
- 
+
     @classmethod
     def from_url(cls, url):
         return cls(url.split("/"))
-    
+
     def is_valid(self) -> bool:
         return len(self.params) > 5 and \
             (self.params[2] == "gallica.bnf.fr" and self.params[3] == "iiif" and self.params[4] == "ark:")
@@ -25,10 +24,14 @@ class GalacticaURL:
         return int(self.params[7][1:])
 
     def zone(self) -> ():
-        return ZONE_FULL if self.params[8] is None or self.params[8] == 'full' else dict(zip(ZONE_KEYS, map(int, self.params[8].split(","))))
+        return ZONE_FULL if self.params[8] is None or self.params[
+            8] == 'full' else dict(
+                zip(ZONE_KEYS, map(int, self.params[8].split(","))))
 
     def size(self) -> ():
-        return SIZE_FULL if self.params[9] is None or self.params[9] == 'full' else dict(zip(SIZE_KEYS, map(int, self.params[9].split(","))))
+        return SIZE_FULL if self.params[9] is None or self.params[
+            9] == 'full' else dict(
+                zip(SIZE_KEYS, map(int, self.params[9].split(","))))
 
     def rotation(self) -> int:
         return int(self.params[10]) | 0
@@ -49,7 +52,8 @@ class GalacticaURL:
         return GalacticaURL(self.params[0:8] + ['info.json'])
 
     def set_zone(self, zone=ZONE_FULL):
-        szone = "full" if zone is None or zone == "full" or zone == ZONE_FULL else ",".join(map(str, zone))
+        szone = "full" if zone is None or zone == "full" or zone == ZONE_FULL else ",".join(
+            map(str, zone))
         parts = self.params[0:8] + [szone] + self.params[9:]
         return GalacticaURL(parts)
 
@@ -79,10 +83,17 @@ def zone_in_zone_as_pct(outer_zone_px, inner_zone_px) -> dict:
 
     w_pct = inner_zone_px['width'] / outer_zone_px['width']
     h_pct = inner_zone_px['height'] / outer_zone_px['height']
-    x_middle_pct = (inner_zone_px['x'] + inner_zone_px['width'] / 2) / outer_zone_px['width']
-    y_middle_pct = (inner_zone_px['y'] + inner_zone_px['height'] / 2) / outer_zone_px['height']
+    x_middle_pct = (inner_zone_px['x'] +
+                    inner_zone_px['width'] / 2) / outer_zone_px['width']
+    y_middle_pct = (inner_zone_px['y'] +
+                    inner_zone_px['height'] / 2) / outer_zone_px['height']
 
-    return {'x': x_middle_pct, 'y': y_middle_pct, 'width': w_pct, 'height': h_pct}
+    return {
+        'x': x_middle_pct,
+        'y': y_middle_pct,
+        'width': w_pct,
+        'height': h_pct
+    }
 
 
 def get_one_field_values(array_of_dict: list, fieldname: str) -> set:
@@ -90,6 +101,7 @@ def get_one_field_values(array_of_dict: list, fieldname: str) -> set:
     for r in array_of_dict:
         values.add(r[fieldname])
     return values
+
 
 def reduce_fields(array_of_dict: list, fieldnames: list) -> list:
     values = []

--- a/src/mdlg/persistence/remoteHttp.py
+++ b/src/mdlg/persistence/remoteHttp.py
@@ -1,11 +1,9 @@
-
 import urllib.request
 from mdlg.model.model import GalacticaURL
 import json
 
 
 class Galactica:
-
     @staticmethod
     def download_image(documentURL: str, filename: str):
         urllib.request.urlretrieve(documentURL, filename)
@@ -30,4 +28,3 @@ class Galactica:
 
 class DRE:
     pass
-

--- a/src/mdlg/services/image_manager.py
+++ b/src/mdlg/services/image_manager.py
@@ -1,5 +1,3 @@
-
-
 # images are physically saved:
 # - in folder TOBEDEFINED, with a zoom version
 # - the information is saved in DB (but not the image itself)
@@ -7,7 +5,6 @@
 
 
 class ImagesManager:
-
     def ensure_content_all_images(self):
         # ensure that each image of the DB has its content downloaded
         pass
@@ -15,5 +12,3 @@ class ImagesManager:
     def ensure_documenting_sizes_of_images(self):
         # download missing sizes from the remote web services
         pass
-
-

--- a/src/mdlg/services/mandragore_dump_manager.py
+++ b/src/mdlg/services/mandragore_dump_manager.py
@@ -1,5 +1,5 @@
 import os
-from mdlg.persistence.db import DBOperationHelper, PersistMandlagore, DBOperationHelper, SQLBuilder
+from mdlg.persistence.db import DBOperationHelper, PersistMandlagore, SQLBuilder
 import collections
 
 
@@ -12,9 +12,11 @@ def _scene_in_images_csv_preprocess(row) -> (list, bool):
     row[1] = row[1][1:]
     return row, skip
 
+
 def _descriptor_image_csv_preprocess(row) -> (list, bool):
     row[1] = row[1][1:]
     return row, False
+
 
 def _descriptor_classe_csv_preprocess(row) -> (list, bool):
     skip = len(row[1]) <= 0
@@ -45,8 +47,8 @@ class MandragoreDumpManager:
             'fields': ["classID", "superclassID"],
             # ".autres invertébrés (vers,arachnides,insectes...)"	"abeille"
             # need to jump equal row where fields are equals
-            'csv' : [1,0],
-            'preprocess' : _classes_csv_preprocess
+            'csv': [1, 0],
+            'preprocess': _classes_csv_preprocess
         },
         'documenturl-gallica.csv': {
             'table': "images",
@@ -79,30 +81,38 @@ class MandragoreDumpManager:
         },
     }
 
-
-    BnfDumpData = collections.namedtuple('BnfDumpData', ['filename', 'encoding', 'table', 'fields', 'mode', 'columns', 'delimiter', 'transform'])
+    BnfDumpData = collections.namedtuple('BnfDumpData', [
+        'filename', 'encoding', 'table', 'fields', 'mode', 'columns',
+        'delimiter', 'transform'
+    ])
     BNF_DUMP_DATA = [
         # 53138757-80	https://gallica.bnf.fr/iiif/ark:/12148/btv1b531387571/f80/full/pct:50/0/native.jpg
-        BnfDumpData('Zoologie-URLs-Gallica.txt', 'utf-8', "images",["imageID", "documentURL"], 
-        DBOperationHelper.SINGLE_RECORD, [0, 1], '\t', None),
+        BnfDumpData('Zoologie-URLs-Gallica.txt', 'utf-8', "images",
+                    ["imageID", "documentURL"],
+                    DBOperationHelper.SINGLE_RECORD, [0, 1], '\t', None),
 
         # 7842457-1	http://visualiseur.bnf.fr/ConsulterElementNum?O=IFN-7842457&E=JPEG&Deb=1&Fin=1&Param=E
-        BnfDumpData('Zoologie-URLs-DRE-Mandragore.txt', 'utf-8', "images",["imageID", "documentURL"], 
-        DBOperationHelper.SINGLE_RECORD, [0, 1], '\t', None),
+        BnfDumpData('Zoologie-URLs-DRE-Mandragore.txt', 'utf-8', "images",
+                    ["imageID", "documentURL"],
+                    DBOperationHelper.SINGLE_RECORD, [0, 1], '\t', None),
 
         # 10507217-143;#78047;#78048;#78049;#78050
-        BnfDumpData('Zoologie-images-notices.csv', 'latin_1', "scenes",["mandragoreID", "imageID"],
-        DBOperationHelper.MULTI_RECORD, [1, 0], ';',_descriptor_image_csv_preprocess),
+        BnfDumpData('Zoologie-images-notices.csv', 'latin_1', "scenes",
+                    ["mandragoreID", "imageID"],
+                    DBOperationHelper.MULTI_RECORD, [1, 0], ';',
+                    _descriptor_image_csv_preprocess),
 
         # 100327;chien (100327);faucon (100327);oiseau (100327);perdrix (100327);
-        BnfDumpData('Zoologie-notices-descripteurs.csv',  'latin_1', "descriptors",["mandragoreID", "classID"],
-        DBOperationHelper.MULTI_RECORD, [0, 1],';', _descriptor_classe_csv_preprocess),
+        BnfDumpData('Zoologie-notices-descripteurs.csv', 'latin_1',
+                    "descriptors", ["mandragoreID", "classID"],
+                    DBOperationHelper.MULTI_RECORD, [0, 1], ';',
+                    _descriptor_classe_csv_preprocess),
 
         # 100327;chien (100327);faucon (100327);oiseau (100327);perdrix (100327);
-        BnfDumpData('Zoologie-notices-descripteurs.csv',  'latin_1', "classes", ["classID"], 
-        DBOperationHelper.MULTI_RECORD, [1], ';', _descriptor_classe_csv_preprocess),
+        BnfDumpData('Zoologie-notices-descripteurs.csv', 'latin_1', "classes",
+                    ["classID"], DBOperationHelper.MULTI_RECORD, [1], ';',
+                    _descriptor_classe_csv_preprocess),
     ]
-
 
     def __init__(self, rootdir: str, persistance: PersistMandlagore):
         self.rootdir = rootdir
@@ -116,11 +126,16 @@ class MandragoreDumpManager:
         dbHelper = DBOperationHelper(self.persistance.conn)
         for doc, params in self.DUMP_DATA.items():
             full_docname = os.path.join(self.rootdir, doc)
-            if not (os.path.exists(full_docname) and os.path.isfile(full_docname)):
+            if not (os.path.exists(full_docname)
+                    and os.path.isfile(full_docname)):
                 # need to warn the file is not processed
-                raise FileNotFoundError("Cannot import basic data as file {} is mising.".format(full_docname))
-            query = SQLBuilder.build_insert_into_query_with_parameters(params["table"], params["fields"])
-            report, warnings = dbHelper.import_csv_file(full_docname, query, params["csv"], params["preprocess"])
+                raise FileNotFoundError(
+                    "Cannot import basic data as file {} is mising.".format(
+                        full_docname))
+            query = SQLBuilder.build_insert_into_query_with_parameters(
+                params["table"], params["fields"])
+            report, warnings = dbHelper.import_csv_file(
+                full_docname, query, params["csv"], params["preprocess"])
             imported.append((doc, report, warnings))
         return imported
 
@@ -131,15 +146,16 @@ class MandragoreDumpManager:
         dbHelper = DBOperationHelper(self.persistance.conn)
         for filename, encoding, tablename, fields, record_mode, columns, delim, transform in self.BNF_DUMP_DATA:
             full_docname = os.path.join(self.rootdir, filename)
-            if not (os.path.exists(full_docname) and os.path.isfile(full_docname)):
+            if not (os.path.exists(full_docname)
+                    and os.path.isfile(full_docname)):
                 # need to warn the file is not processed
-                raise FileNotFoundError("Cannot import basic data as file {} is mising.".format(full_docname))
-            query = SQLBuilder.build_insert_into_query_with_parameters(tablename, fields)
-            report, warnings = dbHelper.import_csv_mode_file(full_docname, query, encoding, delim, record_mode, columns, transform)
+                raise FileNotFoundError(
+                    "Cannot import basic data as file {} is mising.".format(
+                        full_docname))
+            query = SQLBuilder.build_insert_into_query_with_parameters(
+                tablename, fields)
+            report, warnings = dbHelper.import_csv_mode_file(
+                full_docname, query, encoding, delim, record_mode, columns,
+                transform)
             imported.append((filename, report, warnings))
         return imported
-
-
-
-
-

--- a/src/mdlg/services/via_label_manager.py
+++ b/src/mdlg/services/via_label_manager.py
@@ -1,4 +1,3 @@
-
 import json
 import os
 from mdlg.model.model import GalacticaURL, zone_in_zone_as_pct, ZONE_FULL
@@ -85,7 +84,9 @@ class ViaLabelManager:
                 scene = self._describe_one_scene(v)
                 scenes.append(scene)
             except InvalidFilenameError as e:
-                warnings.append("file %s - one scene cannot be prepared for import. Reason : %s" % (filepath, str(e)))
+                warnings.append(
+                    "file %s - one scene cannot be prepared for import. Reason : %s"
+                    % (filepath, str(e)))
 
         return scenes, warnings
 
@@ -97,7 +98,9 @@ class ViaLabelManager:
         # check we are on the Gallactica format
 
         if not url.is_valid():
-            raise InvalidFilenameError('the url : {0} is not a valid galactica url'.format(via_data["filename"]))
+            raise InvalidFilenameError(
+                'the url : {0} is not a valid galactica url'.format(
+                    via_data["filename"]))
 
         # need to check if one of the params is "pct:xx"
         # -> provide the zoom on the image and therefore the right locations
@@ -113,9 +116,14 @@ class ViaLabelManager:
             class_id = region['region_attributes']['Descripteur']
             size_px = region['shape_attributes']
             descriptors.append({'classID': class_id, 'location': size_px})
-        
-        return {'mandragoreID': mandragore_id, 'documentURL': document_url, 'imageID': image_id,
-                'size': size_image, 'descriptors': descriptors}
+
+        return {
+            'mandragoreID': mandragore_id,
+            'documentURL': document_url,
+            'imageID': image_id,
+            'size': size_image,
+            'descriptors': descriptors
+        }
 
     def record_scenes(self, scenes, title='prepare scenes') -> str:
         # ensure to delete data tied to the corresponding 'mandragoreID'
@@ -134,20 +142,35 @@ class ViaLabelManager:
             for sc in bar:
                 mandragore_ids.add(sc['mandragoreID'])
                 image = self.db.retrieve_image(sc['imageID'])
-                gal = GalacticaURL.from_url(sc['documentURL']).set_zone(ZONE_FULL)
+                gal = GalacticaURL.from_url(
+                    sc['documentURL']).set_zone(ZONE_FULL)
                 # TODO - WARNING - we may have a side effect on location of scenes and descriptors if the initial image has been resized in VIA (eg pct:50)
-                if image is None or image['width'] is None or image['height'] is None:
+                if image is None or image['width'] is None or image[
+                        'height'] is None:
                     # need to retrieve the size of the image
                     w, h = self.galactica.collect_image_size(gal.as_url())
-                    images_fields.append({'imageID': sc['imageID'], 'documentURL': gal.as_url(), 'width': w, 'height': h})
+                    images_fields.append({
+                        'imageID': sc['imageID'],
+                        'documentURL': gal.as_url(),
+                        'width': w,
+                        'height': h
+                    })
                 else:
                     w, h = image['width'], image['height']
 
-                scene_info = {'mandragoreID': sc['mandragoreID'], 'imageID': sc['imageID'], 'width': w, 'height': h}
+                scene_info = {
+                    'mandragoreID': sc['mandragoreID'],
+                    'imageID': sc['imageID'],
+                    'width': w,
+                    'height': h
+                }
                 scene_fields.append(scene_info)
 
                 for d in sc['descriptors']:
-                    desc_info = {'mandragoreID': sc['mandragoreID'], 'classID': d['classID']}
+                    desc_info = {
+                        'mandragoreID': sc['mandragoreID'],
+                        'classID': d['classID']
+                    }
                     desc_info.update(d['location'])
                     descriptor_fields.append(desc_info)
         try:
@@ -157,7 +180,8 @@ class ViaLabelManager:
             self.db.add_descriptors(descriptor_fields)
             return "%d scenes imported in DB." % len(scenes)
         except Exception as e:
-            return "Was not able to import the %d scenes in DB. Reason : %s" % (len(scenes), str(e))
+            return "Was not able to import the %d scenes in DB. Reason : %s" % (
+                len(scenes), str(e))
 
     def import_labels(self) -> ():
         report = []
@@ -168,13 +192,6 @@ class ViaLabelManager:
                 rep = self.record_scenes(scenes, f)
                 report.append((f, warnings, rep))
         else:
-            report.append(("--NO FILE--", [], "No .json files found in %s" % self.rootdir))
+            report.append(("--NO FILE--", [],
+                           "No .json files found in %s" % self.rootdir))
         return report
-            
-
-
-
-
-
-
-

--- a/tests/test_mandragore_dump_manager.py
+++ b/tests/test_mandragore_dump_manager.py
@@ -6,8 +6,9 @@ from mdlg.services.mandragore_dump_manager import MandragoreDumpManager
 
 # define the 5 files needed
 
-
-TEST_FILES = { 'classes.csv': """
+TEST_FILES = {
+    'classes.csv':
+    """
 ".amphibiens"	".amphibiens"
 ".amphibiens"	"crapaud"
 ".amphibiens"	"grenouille"
@@ -17,16 +18,19 @@ TEST_FILES = { 'classes.csv': """
 ".autres invertébrés (vers,arachnides,insectes...)"	"alcyonaire"
 ".autres invertébrés (vers,arachnides,insectes...)"	"araignée"
     """,
-    'documenturl-gallica.csv': """
+    'documenturl-gallica.csv':
+    """
 53138757-80	https://gallica.bnf.fr/iiif/ark:/12148/btv1b531387571/f80/full/pct:50/0/native.jpg
 52504824-10	https://gallica.bnf.fr/iiif/ark:/12148/btv1b52504824c/f10/full/pct:50/0/native.jpg
 8453973-65	https://gallica.bnf.fr/iiif/ark:/12148/btv1b8453973c/f65/full/pct:50/0/native.jpg
     """,
-    'documenturl-dre.csv': """
+    'documenturl-dre.csv':
+    """
 7842457-1	http://visualiseur.bnf.fr/ConsulterElementNum?O=IFN-7842457&E=JPEG&Deb=1&Fin=1&Param=E
-7889159-1	http://visualiseur.bnf.fr/ConsulterElementNum?O=IFN-7889159&E=JPEG&Deb=1&Fin=1&Param=E    
-    """, 
-    'descriptors-in-scenes.csv': """
+7889159-1	http://visualiseur.bnf.fr/ConsulterElementNum?O=IFN-7889159&E=JPEG&Deb=1&Fin=1&Param=E
+    """,
+    'descriptors-in-scenes.csv':
+    """
 643	".autres invertébrés (vers,arachnides,insectes...)"	"abeille"	22540	"faune: abeille"	"abeille (22540)"
 643	".autres invertébrés (vers,arachnides,insectes...)"	"abeille"	27600	"s. ambroise et les abeilles"	"abeille (27600)"
 643	".autres invertébrés (vers,arachnides,insectes...)"	"abeille"	29763	"s. ambroise et les abeilles"	"abeille (29763)"
@@ -47,7 +51,8 @@ TEST_FILES = { 'classes.csv': """
 643	".autres invertébrés (vers,arachnides,insectes...)"	"abeille"	69903	"faune: abeille"	"abeille (69903)"
 643	".autres invertébrés (vers,arachnides,insectes...)"	"abeille"	73161	"armes de maffeo barberini"	"abeille (73161)"
     """,
-    'scenes-in-images.csv': """
+    'scenes-in-images.csv':
+    """
 "10020186-20"	"10020186-20"	"10020186"	"20"
 "10020186-20"	"#51326"	"10020186"	"20"
 "52504824-10"	"52504824-10"	"10303825"	"1"
@@ -57,7 +62,8 @@ TEST_FILES = { 'classes.csv': """
 }
 
 TEST_BNF_FILES = {
-    'Zoologie-URLs-Gallica.txt':"""
+    'Zoologie-URLs-Gallica.txt':
+    """
 10303825-1	https://gallica.bnf.fr/iiif/ark:/12148/btv1b531387571/f80/full/pct:50/0/native.jpg
 10308906-65	https://gallica.bnf.fr/iiif/ark:/12148/btv1b53138776d/f23/full/pct:50/0/native.jpg
 52504824-10	https://gallica.bnf.fr/iiif/ark:/12148/btv1b52504824c/f10/full/pct:50/0/native.jpg
@@ -68,7 +74,8 @@ TEST_BNF_FILES = {
 52504824-151	https://gallica.bnf.fr/iiif/ark:/12148/btv1b52504824c/f151/full/pct:50/0/native.jpg
 52504824-173	https://gallica.bnf.fr/iiif/ark:/12148/btv1b52504824c/f173/full/pct:50/0/native.jpg
 """,
-    'Zoologie-URLs-DRE-Mandragore.txt':"""
+    'Zoologie-URLs-DRE-Mandragore.txt':
+    """
 10020186-20	http://visualiseur.bnf.fr/ConsulterElementNum?O=IFN-7864859&E=JPEG&Deb=1&Fin=1&Param=E
 10500687-10	http://visualiseur.bnf.fr/ConsulterElementNum?O=IFN-7823254&E=JPEG&Deb=1&Fin=1&Param=E
 10500687-11	http://visualiseur.bnf.fr/ConsulterElementNum?O=IFN-7823255&E=JPEG&Deb=1&Fin=1&Param=E
@@ -82,7 +89,8 @@ TEST_BNF_FILES = {
 7823280-1	http://visualiseur.bnf.fr/ConsulterElementNum?O=IFN-7823280&E=JPEG&Deb=1&Fin=1&Param=E
 7823291-1	http://visualiseur.bnf.fr/ConsulterElementNum?O=IFN-7823291&E=JPEG&Deb=1&Fin=1&Param=E
 """,
-    'Zoologie-notices-descripteurs.csv':"""
+    'Zoologie-notices-descripteurs.csv':
+    """
 #100001;oiseau (100001);vache (100001);
 #100024;cheval (100024);
 #100026;cheval (100026);
@@ -101,7 +109,8 @@ TEST_BNF_FILES = {
 #52932;poisson (52932);
 #52957;loup (52957);tortue (52957);
 """,
-    'Zoologie-images-notices.csv':"""
+    'Zoologie-images-notices.csv':
+    """
 10020186-20;#209699
 10303825-1;#206804;#206805
 10308906-65;#181563
@@ -111,37 +120,52 @@ TEST_BNF_FILES = {
 """,
 }
 
-class TestViaLabelManager(unittest.TestCase):
 
+class TestViaLabelManager(unittest.TestCase):
     def prepare_data(self, tmpdir: str, files):
         for k, v in files.items():
             datafile = os.path.join(tmpdir, k)
-            with open(datafile, 'w', encoding = 'UTF-8') as content_file:
+            with open(datafile, 'w', encoding='UTF-8') as content_file:
                 content_file.write(v.strip())
 
     def verify_db_content(self, db, totests):
         sqls = [l for l in db.conn.iterdump()]
 
-        # verify some data 
+        # verify some data
         cur = db.conn.cursor()
         for query, exist in totests.items():
             cur.execute(query)
             rows = cur.fetchall()
-            self.assertEqual(exist, len(rows) > 0, "invalid result in request : {} - value {} expect".format(query, exist))
+            self.assertEqual(
+                exist,
+                len(rows) > 0,
+                "invalid result in request : {} - value {} expect".format(
+                    query, exist))
 
     def test_reorganized_dumps(self):
         queries = {
-            "SELECT * FROM classes": True,
-            "SELECT * FROM classes WHERE classID = 'abeille'": True,
-            "SELECT * FROM classes WHERE classID = 'lion'": False,
-            "SELECT * FROM images WHERE imageID = '7842457-1'": True,
-            "SELECT * FROM images WHERE imageID = '52504824-10'": True,
-            "SELECT * FROM scenes WHERE mandragoreID = '51326'": True,
-            "SELECT * FROM scenes WHERE mandragoreID = 40999 AND imageID = '52504824-10'": True,
-            "SELECT * FROM scenes WHERE mandragoreID = 40999 AND imageID = '7842457-1'": False,
-            "SELECT * FROM descriptors WHERE classID = 'abeille'": True,
-            "SELECT * FROM descriptors WHERE classID = 'abeille' AND mandragoreID = 51125": True,
-            "SELECT * FROM descriptors WHERE classID = 'oreilles' AND mandragoreID = 51125": False,
+            "SELECT * FROM classes":
+            True,
+            "SELECT * FROM classes WHERE classID = 'abeille'":
+            True,
+            "SELECT * FROM classes WHERE classID = 'lion'":
+            False,
+            "SELECT * FROM images WHERE imageID = '7842457-1'":
+            True,
+            "SELECT * FROM images WHERE imageID = '52504824-10'":
+            True,
+            "SELECT * FROM scenes WHERE mandragoreID = '51326'":
+            True,
+            "SELECT * FROM scenes WHERE mandragoreID = 40999 AND imageID = '52504824-10'":
+            True,
+            "SELECT * FROM scenes WHERE mandragoreID = 40999 AND imageID = '7842457-1'":
+            False,
+            "SELECT * FROM descriptors WHERE classID = 'abeille'":
+            True,
+            "SELECT * FROM descriptors WHERE classID = 'abeille' AND mandragoreID = 51125":
+            True,
+            "SELECT * FROM descriptors WHERE classID = 'oreilles' AND mandragoreID = 51125":
+            False,
         }
 
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -156,17 +180,28 @@ class TestViaLabelManager(unittest.TestCase):
 
     def test_bnf_dumps(self):
         queries = {
-            "SELECT * FROM classes": True,
-            "SELECT * FROM classes WHERE classID = 'biche'": True,
-            "SELECT * FROM classes WHERE classID = 'abeille'": False,
-            "SELECT * FROM images WHERE imageID = '7823277-1'": True,
-            "SELECT * FROM images WHERE imageID = '52504824-151'": True,
-            "SELECT * FROM scenes WHERE mandragoreID = '52957'": True,
-            "SELECT * FROM scenes WHERE mandragoreID = 181563 AND imageID = '10308906-65'": True,
-            "SELECT * FROM scenes WHERE mandragoreID = 40999 AND imageID = '10500687-147'": False,
-            "SELECT * FROM descriptors WHERE classID = 'taureau'": True,
-            "SELECT * FROM descriptors WHERE classID = 'taureau' AND mandragoreID = 10005": True,
-            "SELECT * FROM descriptors WHERE classID = 'oreilles' AND mandragoreID = 10005": False,
+            "SELECT * FROM classes":
+            True,
+            "SELECT * FROM classes WHERE classID = 'biche'":
+            True,
+            "SELECT * FROM classes WHERE classID = 'abeille'":
+            False,
+            "SELECT * FROM images WHERE imageID = '7823277-1'":
+            True,
+            "SELECT * FROM images WHERE imageID = '52504824-151'":
+            True,
+            "SELECT * FROM scenes WHERE mandragoreID = '52957'":
+            True,
+            "SELECT * FROM scenes WHERE mandragoreID = 181563 AND imageID = '10308906-65'":
+            True,
+            "SELECT * FROM scenes WHERE mandragoreID = 40999 AND imageID = '10500687-147'":
+            False,
+            "SELECT * FROM descriptors WHERE classID = 'taureau'":
+            True,
+            "SELECT * FROM descriptors WHERE classID = 'taureau' AND mandragoreID = 10005":
+            True,
+            "SELECT * FROM descriptors WHERE classID = 'oreilles' AND mandragoreID = 10005":
+            False,
         }
 
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -179,5 +214,3 @@ class TestViaLabelManager(unittest.TestCase):
                 # now try to import the files
                 mng.load_bnf_data()
                 self.verify_db_content(db, queries)
-
-

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -8,24 +8,47 @@ class TestGalacticaURL(unittest.TestCase):
         url = "https://gallica.bnf.fr/iiif/ark:/12148/btv1bDOCUMENTIDd/f200/11,12,13,14/full/0/native.jpg-1"
         gal = GalacticaURL.from_url(url)
 
-        self.assertTrue(gal.is_valid(), 'url {0} expected to be true'.format(url))
+        self.assertTrue(gal.is_valid(),
+                        'url {0} expected to be true'.format(url))
         self.assertEqual("DOCUMENTID", gal.document_id())
         self.assertEqual(200, gal.page_number())
-        self.assertEqual({'x': 11, 'y': 12, 'width': 13, 'height': 14}, gal.zone())
+        self.assertEqual({
+            'x': 11,
+            'y': 12,
+            'width': 13,
+            'height': 14
+        }, gal.zone())
         self.assertEqual('DOCUMENTID_200', gal.as_filename())
-        self.assertEqual("https://gallica.bnf.fr/iiif/ark:/12148/btv1bDOCUMENTIDd/f200/info.json", gal.url_image_properties().as_url())
-        self.assertEqual("https://gallica.bnf.fr/iiif/ark:/12148/btv1bDOCUMENTIDd/f200/full/full/0/native.jpg-1", gal.set_zone().as_url())
-        self.assertEqual("https://gallica.bnf.fr/iiif/ark:/12148/btv1bDOCUMENTIDd/f200/full/full/0/native.jpg-1", gal.set_zone(None).as_url())
-        self.assertEqual("https://gallica.bnf.fr/iiif/ark:/12148/btv1bDOCUMENTIDd/f200/full/full/0/native.jpg-1", gal.set_zone(ZONE_FULL).as_url())
-        self.assertEqual("https://gallica.bnf.fr/iiif/ark:/12148/btv1bDOCUMENTIDd/f200/1,2,3,4/full/0/native.jpg-1", gal.set_zone((1, 2, 3, 4)).as_url())
-        self.assertEqual("https://gallica.bnf.fr/iiif/ark:/12148/btv1bDOCUMENTIDd/f200/1,2,3,4/full/0/native.jpg-1",
-                         gal.set_zone((1, 2, 3, 4)).set_size(None).as_url())
-        self.assertEqual("https://gallica.bnf.fr/iiif/ark:/12148/btv1bDOCUMENTIDd/f200/1,2,3,4/full/0/native.jpg-1", 
-                         gal.set_zone((1, 2, 3, 4)).set_size(SIZE_FULL).as_url())
-        self.assertEqual("https://gallica.bnf.fr/iiif/ark:/12148/btv1bDOCUMENTIDd/f200/1,2,3,4/20,40/0/native.jpg-1",
-                         gal.set_zone((1, 2, 3, 4)).set_size((20, 40)).as_url())
-        self.assertEqual("https://gallica.bnf.fr/iiif/ark:/12148/btv1bDOCUMENTIDd/f200/11,12,13,14/full/90/native.jpg-1", gal.set_rotation(90).as_url())
-        self.assertEqual("https://gallica.bnf.fr/iiif/ark:/12148/btv1bDOCUMENTIDd/f200/11,12,13,14/full/0/bicolor.jpg-1", gal.set_quality('bicolor').as_url())
-        self.assertEqual("https://gallica.bnf.fr/iiif/ark:/12148/btv1bDOCUMENTIDd/f200/11,12,13,14/full/0/bicolor.png",
-                         gal.set_quality('bicolor').set_file_format('png').as_url())
-
+        self.assertEqual(
+            "https://gallica.bnf.fr/iiif/ark:/12148/btv1bDOCUMENTIDd/f200/info.json",
+            gal.url_image_properties().as_url())
+        self.assertEqual(
+            "https://gallica.bnf.fr/iiif/ark:/12148/btv1bDOCUMENTIDd/f200/full/full/0/native.jpg-1",
+            gal.set_zone().as_url())
+        self.assertEqual(
+            "https://gallica.bnf.fr/iiif/ark:/12148/btv1bDOCUMENTIDd/f200/full/full/0/native.jpg-1",
+            gal.set_zone(None).as_url())
+        self.assertEqual(
+            "https://gallica.bnf.fr/iiif/ark:/12148/btv1bDOCUMENTIDd/f200/full/full/0/native.jpg-1",
+            gal.set_zone(ZONE_FULL).as_url())
+        self.assertEqual(
+            "https://gallica.bnf.fr/iiif/ark:/12148/btv1bDOCUMENTIDd/f200/1,2,3,4/full/0/native.jpg-1",
+            gal.set_zone((1, 2, 3, 4)).as_url())
+        self.assertEqual(
+            "https://gallica.bnf.fr/iiif/ark:/12148/btv1bDOCUMENTIDd/f200/1,2,3,4/full/0/native.jpg-1",
+            gal.set_zone((1, 2, 3, 4)).set_size(None).as_url())
+        self.assertEqual(
+            "https://gallica.bnf.fr/iiif/ark:/12148/btv1bDOCUMENTIDd/f200/1,2,3,4/full/0/native.jpg-1",
+            gal.set_zone((1, 2, 3, 4)).set_size(SIZE_FULL).as_url())
+        self.assertEqual(
+            "https://gallica.bnf.fr/iiif/ark:/12148/btv1bDOCUMENTIDd/f200/1,2,3,4/20,40/0/native.jpg-1",
+            gal.set_zone((1, 2, 3, 4)).set_size((20, 40)).as_url())
+        self.assertEqual(
+            "https://gallica.bnf.fr/iiif/ark:/12148/btv1bDOCUMENTIDd/f200/11,12,13,14/full/90/native.jpg-1",
+            gal.set_rotation(90).as_url())
+        self.assertEqual(
+            "https://gallica.bnf.fr/iiif/ark:/12148/btv1bDOCUMENTIDd/f200/11,12,13,14/full/0/bicolor.jpg-1",
+            gal.set_quality('bicolor').as_url())
+        self.assertEqual(
+            "https://gallica.bnf.fr/iiif/ark:/12148/btv1bDOCUMENTIDd/f200/11,12,13,14/full/0/bicolor.png",
+            gal.set_quality('bicolor').set_file_format('png').as_url())

--- a/tests/test_remotehttp.py
+++ b/tests/test_remotehttp.py
@@ -14,20 +14,26 @@ class FakeReqOpener:
 
     def read(self):
         return json.dumps({
-            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
-            "width": 100,
-            "height": 200,
-            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
-            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8470209d/f11"
+            "profile":
+            "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+            "width":
+            100,
+            "height":
+            200,
+            "@context":
+            "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+            "@id":
+            "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8470209d/f11"
         })
 
-class TestRemoteHTTP(unittest.TestCase):
 
+class TestRemoteHTTP(unittest.TestCase):
     @patch('mdlg.persistence.remoteHttp.urllib.request.urlopen')
     def test_collect_image_size(self, mock_urlopen):
         mock_urlopen.return_value = FakeReqOpener()
 
-        width, height = Galactica.collect_image_size("https://gallica.bnf.fr/iiif/ark:/12148/btv1b8470209d/f11/info.json")
+        width, height = Galactica.collect_image_size(
+            "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8470209d/f11/info.json"
+        )
         self.assertEqual(100, width)
         self.assertEqual(200, height)
-

--- a/tests/test_via_label_manager.py
+++ b/tests/test_via_label_manager.py
@@ -5,57 +5,94 @@ import tempfile
 from mdlg.services.via_label_manager import ViaLabelManager
 import os
 
-
-gallica_12148_f11 = {"https://gallica.bnf.fr/iiif/ark:/12148/btv1b8470209d/f11/398,195,2317,3945/full/0/native.jpg-1":
-     {"filename":"https://gallica.bnf.fr/iiif/ark:/12148/btv1b8470209d/f11/398,195,2317,3945/full/0/native.jpg", 
-      "size":-1, 
-      "regions":[ 
-          {"shape_attributes":
-               {"name":"rect",
-                "x":449,
-                "y":1610,
-                "width":1363,
-                "height":1257},
-           "region_attributes":
-               {"Descripteur":"armoiries",
-                "Type":"objet"}
-          },
-          {"shape_attributes":{
-              "name":"rect",
-              "x":656,
-              "y":122,
-              "width":875,
-              "height":568},
-            "region_attributes":{
-                "Descripteur":"serpent",
-                "Type":"objet"}
-          },
-      ],
-      "file_attributes":{
-          "MandragoreId":"60106"
-      },
+gallica_12148_f11 = {
+    "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8470209d/f11/398,195,2317,3945/full/0/native.jpg-1":
+    {
+        "filename":
+        "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8470209d/f11/398,195,2317,3945/full/0/native.jpg",
+        "size": -1,
+        "regions": [
+            {
+                "shape_attributes": {
+                    "name": "rect",
+                    "x": 449,
+                    "y": 1610,
+                    "width": 1363,
+                    "height": 1257
+                },
+                "region_attributes": {
+                    "Descripteur": "armoiries",
+                    "Type": "objet"
+                }
+            },
+            {
+                "shape_attributes": {
+                    "name": "rect",
+                    "x": 656,
+                    "y": 122,
+                    "width": 875,
+                    "height": 568
+                },
+                "region_attributes": {
+                    "Descripteur": "serpent",
+                    "Type": "objet"
+                }
+            },
+        ],
+        "file_attributes": {
+            "MandragoreId": "60106"
+        },
     }
- }
+}
 
-SCENES = [
-    {'mandragoreID': 'ID1',
-     'documentURL': 'https://gallica.bnf.fr/iiif/ark:/12148/doc/page1/5,5,10,40/full/0/native.jpg',
-     'imageID': 'doc-page1',
-     'size': {'x': 1, 'y': 1, 'width': 100, 'height': 200},
-     'descriptors': [
-         {'classID': 'dog', 'location': {'x': 5, 'y': 5, 'width': 10, 'height': 40}}]
-     },
-    {'mandragoreID': 'ID2',
-     'documentURL': 'https://gallica.bnf.fr/iiif/ark:/12148/doc/page2/2,2,200,500/full/0/native.jpg',
-     'imageID': 'doc-page2',
-     'size': {'x': 2, 'y': 2, 'width': 200, 'height': 500},
-     'descriptors': [
-         {'classID': 'dog', 'location': {'x': 50, 'y': 50, 'width': 20, 'height': 100}}]
-     }
-]
+SCENES = [{
+    'mandragoreID':
+    'ID1',
+    'documentURL':
+    'https://gallica.bnf.fr/iiif/ark:/12148/doc/page1/5,5,10,40/full/0/native.jpg',
+    'imageID':
+    'doc-page1',
+    'size': {
+        'x': 1,
+        'y': 1,
+        'width': 100,
+        'height': 200
+    },
+    'descriptors': [{
+        'classID': 'dog',
+        'location': {
+            'x': 5,
+            'y': 5,
+            'width': 10,
+            'height': 40
+        }
+    }]
+}, {
+    'mandragoreID':
+    'ID2',
+    'documentURL':
+    'https://gallica.bnf.fr/iiif/ark:/12148/doc/page2/2,2,200,500/full/0/native.jpg',
+    'imageID':
+    'doc-page2',
+    'size': {
+        'x': 2,
+        'y': 2,
+        'width': 200,
+        'height': 500
+    },
+    'descriptors': [{
+        'classID': 'dog',
+        'location': {
+            'x': 50,
+            'y': 50,
+            'width': 20,
+            'height': 100
+        }
+    }]
+}]
+
 
 class TestViaLabelManager(unittest.TestCase):
-
     def test_describe_one_scene(self):
 
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -71,26 +108,49 @@ class TestViaLabelManager(unittest.TestCase):
         self.assertEqual(0, len(warnings))
         f11 = scenes[0]
         self.assertEqual("60106", f11['mandragoreID'])
-        self.assertEqual("https://gallica.bnf.fr/iiif/ark:/12148/btv1b8470209d/f11/398,195,2317,3945/full/0/native.jpg", f11['documentURL'])
+        self.assertEqual(
+            "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8470209d/f11/398,195,2317,3945/full/0/native.jpg",
+            f11['documentURL'])
         self.assertEqual("8470209-11", f11['imageID'])
-        self.assertDictEqual({'x':398, 'y':195, 'width':2317, 'height': 3945}, f11['size'])
+        self.assertDictEqual(
+            {
+                'x': 398,
+                'y': 195,
+                'width': 2317,
+                'height': 3945
+            }, f11['size'])
         self.assertEqual(2, len(f11['descriptors']))
         self.assertEqual('armoiries', f11['descriptors'][0]['classID'])
         self.assertEqual('serpent', f11['descriptors'][1]['classID'])
 
     def test_record_scenes(self):
-        with unittest.mock.patch('mdlg.persistence.db.PersistMandlagore',  autospec=True) as MockDB:
-            with unittest.mock.patch('mdlg.persistence.remoteHttp.Galactica', autospec=True) as MockGalactica:
+        with unittest.mock.patch('mdlg.persistence.db.PersistMandlagore',
+                                 autospec=True) as MockDB:
+            with unittest.mock.patch('mdlg.persistence.remoteHttp.Galactica',
+                                     autospec=True) as MockGalactica:
                 with MockDB() as db:
                     db.retrieve_image.return_value = None
                     gal = MockGalactica()
-                    gal.collect_image_size.return_value=(1000,2000)
+                    gal.collect_image_size.return_value = (1000, 2000)
                     vlm = ViaLabelManager(None, db, gal)
 
                     vlm.record_scenes(SCENES)
 
-                    db.delete_mandragore_related.assert_called_once_with(frozenset(['ID1', 'ID2']))
+                    db.delete_mandragore_related.assert_called_once_with(
+                        frozenset(['ID1', 'ID2']))
                     db.ensure_images.assert_called_once_with([
-                        {'imageID': 'doc-page1', 'documentURL':'https://gallica.bnf.fr/iiif/ark:/12148/doc/page1/full/full/0/native.jpg', 'width':1000, 'height':2000},
-                        {'imageID': 'doc-page2', 'documentURL':'https://gallica.bnf.fr/iiif/ark:/12148/doc/page2/full/full/0/native.jpg', 'width':1000, 'height':2000},
+                        {
+                            'imageID': 'doc-page1',
+                            'documentURL':
+                            'https://gallica.bnf.fr/iiif/ark:/12148/doc/page1/full/full/0/native.jpg',
+                            'width': 1000,
+                            'height': 2000
+                        },
+                        {
+                            'imageID': 'doc-page2',
+                            'documentURL':
+                            'https://gallica.bnf.fr/iiif/ark:/12148/doc/page2/full/full/0/native.jpg',
+                            'width': 1000,
+                            'height': 2000
+                        },
                     ])


### PR DESCRIPTION
Adding PEP8 checking, and tool for formatting in my VSCode IDE
Theses are the parameters of my .vscode/.settings.json:

```
{
    "python.testing.unittestArgs": [
        "-v",
        "-s",
        "./tests",
        "-p",
        "test_*.py"
    ],
    "python.testing.pytestEnabled": false,
    "python.testing.nosetestsEnabled": false,
    "python.testing.unittestEnabled": true,
    "python.pythonPath": "/anaconda3/envs/another/bin/python",
    "python.linting.enabled": true,
    "python.linting.flake8Enabled": true,
    "python.linting.flake8Args": [
        "--max-line-length=160",
        "--ignore=E402,F841,F401,E302,E305,W504,W503",
    ],
    "editor.formatOnSave": true,
    "python.formatting.provider": "yapf"
}
```