### PR TITLE
transform HTTP downloader in ContextManager to include requests.Session

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ python3 mdcli.py labels
 
 ### download image content and image sizes from Galactica
 
-the API of Galactica, for collecting images on demand, is available on (IIIF's API for fetching images from Gallica)[http://api.bnf.fr/api-iiif-de-recuperation-des-images-de-gallica]
+the API of Galactica, for collecting images on demand, is available on [IIIF's API for fetching images from Gallica](http://api.bnf.fr/api-iiif-de-recuperation-des-images-de-gallica)
 Mandlagore keep metadata of the images in the BD, and their content in local files available at `${MDLG-DATA}/images/galactica`
 to download missing content and missing metadata (the size of images), cun cli:
 

--- a/src/mdlg/mdcli.py
+++ b/src/mdlg/mdcli.py
@@ -1,7 +1,7 @@
 import click
 import os
 from mdlg.persistence.db import PersistMandlagore
-from mdlg.persistence.remoteHttp import Galactica
+from mdlg.persistence.remoteHttp import GalacticaSession
 from mdlg.services.mandragore_dump_manager import MandragoreDumpManager
 from mdlg.services.via_label_manager import ViaLabelManager
 from mdlg.services.image_manager import ImagesManager
@@ -169,9 +169,8 @@ def mandragore(mdlgenv: MdlgEnv):
 def labels(mdlgenv: MdlgEnv):
     # load labels frol all the VIA annotation files available in the import folder
     pathdb = mdlgenv.db_filename()
-    with PersistMandlagore(pathdb) as db:
+    with PersistMandlagore(pathdb) as db, GalacticaSession() as gal:
         dname = mdlgenv.via_annotation_dirname()
-        gal = Galactica
         vlm = ViaLabelManager(dname, db, gal)
         report = vlm.import_labels()
 
@@ -227,8 +226,8 @@ def galactica(mdlgenv: MdlgEnv, images, scenes, descriptors, limit, dryrun, fake
     filter = [build_filter_from_option('images', f) for f in images]
     filter += [build_filter_from_option('scenes', f) for f in scenes]
     filter += [build_filter_from_option('descriptors', f) for f in descriptors]
-    with PersistMandlagore(pathdb) as db:
-        imgr = ImagesManager(mdlgenv.source_images_galactica_dirname(), db)
+    with PersistMandlagore(pathdb) as db, GalacticaSession() as gal:
+        imgr = ImagesManager(mdlgenv.source_images_galactica_dirname(), db, gal)
         imgr.ensure_content_images(filter, limit, dryrun, faked)
 
 @mdcli.command()

--- a/src/mdlg/model/model.py
+++ b/src/mdlg/model/model.py
@@ -11,7 +11,9 @@ class GalacticaURL:
 
     @classmethod
     def from_url(cls, url):
-        return cls(url.split("/"))
+        parts = url.split("/")
+        parts += ([''] * (12 - len(parts)))
+        return cls(parts)
 
     def is_valid(self) -> bool:
         return len(self.params) > 5 and \
@@ -36,7 +38,8 @@ class GalacticaURL:
         return self.params[11].split(".")[0]
 
     def file_format(self) -> str:
-        return self.params[11].split(".")[1]
+        end = self.params[11].split(".")
+        return end[1] if len(end)>1 else ""
 
     def as_filename(self) -> str:
         # TDO - review if we want to encode subset/rotation/zoom in the file

--- a/tests/test_via_label_manager.py
+++ b/tests/test_via_label_manager.py
@@ -126,7 +126,7 @@ class TestViaLabelManager(unittest.TestCase):
     def test_record_scenes(self):
         with unittest.mock.patch('mdlg.persistence.db.PersistMandlagore',
                                  autospec=True) as MockDB:
-            with unittest.mock.patch('mdlg.persistence.remoteHttp.Galactica',
+            with unittest.mock.patch('mdlg.persistence.remoteHttp.GalacticaSession',
                                      autospec=True) as MockGalactica:
                 with MockDB() as db:
                     db.retrieve_image.return_value = None


### PR DESCRIPTION
At the end, does not do much difference : 
* Galactica website is long to reply, session or not. (3 to 4 sec for a content query)
* when asking a reduction of the image, it seems Galactica it takin several seconds to perform that operation before returning the result
